### PR TITLE
Allow specification of number of columns with manual timestamps

### DIFF
--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -35,7 +35,10 @@ def test_grid_rows_integer():
     assert_equals(test_grid.x, 4)
     assert_equals(test_grid.y, -1)
 
-    assert_raises(ArgumentTypeError, mxn_type, '4x1x4')
+    test_grid = mxn_type('4x1x4')
+
+    assert_equals(test_grid.x, 4)
+    assert_equals(test_grid.y, 1)
 
 
 def test_grid_format():

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -31,7 +31,7 @@ def test_grid_rows_integer():
     assert_raises(ArgumentTypeError, mxn_type, '4x4.1')
 
 
-def test_grid_columns_positive():
+def test_grid_rows_positive():
     assert_raises(ArgumentTypeError, mxn_type, '4x-1')
 
 

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -30,20 +30,16 @@ def test_grid_rows_integer():
 
     assert_raises(ArgumentTypeError, mxn_type, '4x4.1')
 
-    test_grid = mxn_type('4x-1')
 
-    assert_equals(test_grid.x, 4)
-    assert_equals(test_grid.y, -1)
-
-    test_grid = mxn_type('4x1x4')
-
-    assert_equals(test_grid.x, 4)
-    assert_equals(test_grid.y, 1)
+def test_grid_columns_positive():
+    assert_raises(ArgumentTypeError, mxn_type, '4x-1')
 
 
 def test_grid_format():
     assert_raises(ArgumentTypeError, mxn_type, '')
 
     assert_raises(ArgumentTypeError, mxn_type, '4xx4')
+
+    assert_raises(ArgumentTypeError, mxn_type, '4x1x4')
 
     assert_raises(ArgumentTypeError, mxn_type, '4')

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,0 +1,46 @@
+from argparse import ArgumentTypeError
+
+from nose.tools import assert_raises
+from nose.tools import assert_equals
+
+from vcsi.vcsi import Grid, mxn_type
+
+
+def test_grid_default():
+    test_grid = mxn_type('4x4')
+
+    assert_equals(test_grid.x, 4)
+    assert_equals(test_grid.y, 4)
+
+
+def test_grid_columns_integer():
+    assert_raises(ArgumentTypeError, mxn_type, 'ax4')
+
+    assert_raises(ArgumentTypeError, mxn_type, '4.1x4')
+
+
+def test_grid_columns_positive():
+    assert_raises(ArgumentTypeError, mxn_type, '-1x4')
+
+    assert_raises(ArgumentTypeError, mxn_type, '0x4')
+
+
+def test_grid_rows_integer():
+    assert_raises(ArgumentTypeError, mxn_type, '4xa')
+
+    assert_raises(ArgumentTypeError, mxn_type, '4x4.1')
+
+    test_grid = mxn_type('4x-1')
+
+    assert_equals(test_grid.x, 4)
+    assert_equals(test_grid.y, -1)
+
+    assert_raises(ArgumentTypeError, mxn_type, '4x1x4')
+
+
+def test_grid_format():
+    assert_raises(ArgumentTypeError, mxn_type, '')
+
+    assert_raises(ArgumentTypeError, mxn_type, '4xx4')
+
+    assert_raises(ArgumentTypeError, mxn_type, '4')

--- a/vcsi/vcsi.py
+++ b/vcsi/vcsi.py
@@ -947,9 +947,11 @@ def mxn_type(string):
     """
     try:
         split = string.split("x")
+        assert (len(split) == 2)
         m = int(split[0])
         assert (m > 0)
         n = int(split[1])
+        assert (n > 0)
         return Grid(m, n)
     except (IndexError, ValueError, AssertionError):
         error = "Grid must be of the form mxn, where m is the number of columns and n is the number of rows."


### PR DESCRIPTION
Problem: 
I want to specify manual timestamps but I do not want to specify the full grid value.

Currently:
`vcsi.py -m 5:00,10:00,15:00 foo.mkv`
produces a 1x3 grid.

`vcsi.py -g 2x2 -m 5:00,10:00,15:00 foo.mkv`
produces a 1x3 grid.

`vcsi.py -g 4x1 -m 5:00,10:00,15:00 foo.mkv`
produces a 1x3 grid.




This patch allows specification of the number of columns.
`vcsi.py -g 2x2 -m 5:00,10:00,15:00 foo.mkv`
produces a 2x2 grid with one empty slot.


If we want this could easily be a `-c/--columns` flag.


I do want to implement an `--interval` or `--range` to avoid providing all of the manual timestamps on the command line.
Overall this helps facilitate the output when we do not know the `num_selected`