### PR TITLE
modified process_file() for a better "--no-overwrite" experience

### DIFF
--- a/vcsi/vcsi.py
+++ b/vcsi/vcsi.py
@@ -1401,6 +1401,18 @@ def process_file(path, args):
             error_message = "File does not exist: {}".format(path)
             error_exit(error_message)
 
+    if path.lower().endswith(args.image_format.lower()):
+        return
+
+    output_path = args.output_path
+    if not output_path:
+        output_path = path + "." + args.image_format
+
+    if args.no_overwrite:
+        if os.path.exists(output_path):
+            print("[INFO] contact-sheet already exists, skipping: {}".format(output_path))
+            return
+
     print("Processing {}...".format(path))
 
     media_info = MediaInfo(
@@ -1412,16 +1424,6 @@ def process_file(path, args):
         skip_delay_seconds=args.accurate_delay_seconds,
         frame_type=args.frame_type
     )
-
-    output_path = args.output_path
-    if not output_path:
-        output_path = media_info.filename + "." + args.image_format
-
-    if args.no_overwrite:
-        if os.path.exists(output_path):
-            print("[WARN] Output file already exists, skipping: {}".format(output_path))
-            return
-
 
     # metadata margins
     if not args.metadata_margin == DEFAULT_METADATA_MARGIN:


### PR DESCRIPTION
When I initially create contact-sheets in a video-folder the recursive functionality from vcsi works fine. But when I only want to create the contact-sheets for NEW videos - vcsi works not at it's best.

I can use the "--no-overwrite" mode, but it still parses the video. Also it find's the contact-sheets itself and tries to parse them as well (which results in errors). If I then use --ignore-errors it works better. But then I don't see errors anymore ;-)

So I slightly adjusted the process_file() method and moved the file check to the front of the method. Now i can just say "vcsi --no-overwrite ." in a folder over and over again and still get potential errors during contact-sheet generation.