### PR TITLE
Add Unicode fallbacks on Windows, prioritizing CJK fonts

### DIFF
--- a/vcsi/vcsi.py
+++ b/vcsi/vcsi.py
@@ -79,7 +79,6 @@ if os.name == 'nt':
     DEFAULT_METADATA_FONT = "C:/Windows/Fonts/msgothic.ttc"
     DEFAULT_TIMESTAMP_FONT = "C:/Windows/Fonts/msgothic.ttc"
     FALLBACK_FONTS = [
-        "C:/Windows/Fonts/msgothic.ttc",
         "C:/Windows/Fonts/simsun.ttc",
         "C:/Windows/Fonts/Everson Mono.ttf",
         "C:/Windows/Fonts/calibri.ttf",

--- a/vcsi/vcsi.py
+++ b/vcsi/vcsi.py
@@ -67,12 +67,25 @@ DEFAULT_CONFIG_FILE = os.path.join(os.path.expanduser("~"), ".config/vcsi.conf")
 DEFAULT_CONFIG_SECTION = "vcsi"
 
 DEFAULT_METADATA_FONT_SIZE = 16
-DEFAULT_METADATA_FONT = "/usr/share/fonts/TTF/DejaVuSans-Bold.ttf"
 DEFAULT_TIMESTAMP_FONT_SIZE = 12
+
+# Defaults
+DEFAULT_METADATA_FONT = "/usr/share/fonts/TTF/DejaVuSans-Bold.ttf"
 DEFAULT_TIMESTAMP_FONT = "/usr/share/fonts/TTF/DejaVuSans.ttf"
-FALLBACK_FONTS = [
-    "/Library/Fonts/Arial Unicode.ttf"
-]
+FALLBACK_FONTS = ["/Library/Fonts/Arial Unicode.ttf"]
+
+# Replace defaults on Windows to support unicode/CJK and multiple fallbacks
+if os.name == 'nt':
+    DEFAULT_METADATA_FONT = "C:/Windows/Fonts/msgothic.ttc"
+    DEFAULT_TIMESTAMP_FONT = "C:/Windows/Fonts/msgothic.ttc"
+    FALLBACK_FONTS = [
+        "C:/Windows/Fonts/msgothic.ttc",
+        "C:/Windows/Fonts/simsun.ttc",
+        "C:/Windows/Fonts/Everson Mono.ttf",
+        "C:/Windows/Fonts/calibri.ttf",
+        "C:/Windows/Fonts/arial.ttf"
+    ]
+
 DEFAULT_CONTACT_SHEET_WIDTH = 1500
 DEFAULT_DELAY_PERCENT = None
 DEFAULT_START_DELAY_PERCENT = 7


### PR DESCRIPTION
This PR replaces the default fonts on windows to add Unicode support. I noticed there were several problems on windows with any type of Unicode in the filename or path, spaces, etc. I've defaulted to builtin Microsoft CJK unicode fonts and fall back several layers though options and finally default to Arial which has okay Unicode support. I borrowed a Youtube video as a test scenario.

Tested On:

- Windows 10 Professional Version 10.0.18362
- Python 3.7.4

---

**Before:**
Won't execute, winds up with a stack dump.
```
Processing .\20190921 - こんにちは、ガチョウです #01【Untitled Goose Game】 - [NJBd1WA37ew].mp4...
Sampling... 16/16
Composing contact sheet...
Falling back to default font.
Falling back to default font.
    main()
  File "C:\Dev\Cloned\vcsi\vcsi\vcsi.py", line 1615, in main
    process_file_or_ignore(filename, args)
  File "C:\Dev\Cloned\vcsi\vcsi\vcsi.py", line 1589, in process_file_or_ignore
    process_file(filepath, args)
  File "C:\Dev\Cloned\vcsi\vcsi\vcsi.py", line 1746, in process_file
    image = compose_contact_sheet(media_info, selected_frames, args)
  File "C:\Dev\Cloned\vcsi\vcsi\vcsi.py", line 954, in compose_contact_sheet
    template_path=args.metadata_template_path)
  File "C:\Dev\Cloned\vcsi\vcsi\vcsi.py", line 865, in prepare_metadata_text_lines
    text=remaining_chars)
  File "C:\Dev\Cloned\vcsi\vcsi\vcsi.py", line 829, in max_line_length
    text_width = 0 if len(text_chunk) == 0 else metadata_font.getsize(text_chunk)[0]
  File "C:\Dev\Lang\python-3.7.4\lib\site-packages\PIL\ImageFont.py", line 120, in getsize
    return self.font.getsize(text)
UnicodeEncodeError: 'latin-1' codec can't encode character '\u3053' in position 11: ordinal not in range(256)
```

---

**After Best Case:**
```
> python C:\Dev\Cloned\vcsi\vcsi\vcsi.py -w 1024 '.\20190921 - こんにちは、ガチョウです #01【Untitled Goose Game】 - [NJBd1WA37ew].mp4'
Sampling... 16/16
Composing contact sheet...
Cleaning up temporary files...
```
Contact Sheet:
![image](https://user-images.githubusercontent.com/2738686/71571534-9f541880-2a8f-11ea-83ed-bf63f04aeff2.png)

**After Worst Case (Fallback all the way to Arial):**
![image](https://user-images.githubusercontent.com/2738686/71571591-d4f90180-2a8f-11ea-9e39-933b112e1a2d.png)

So at least in the worst case, you may wind up with missing characters, but you will still get your contact sheet.