### PR TITLE
consider filename starting with -

### DIFF
--- a/vcsi/vcsi.py
+++ b/vcsi/vcsi.py
@@ -201,6 +201,7 @@ class MediaInfo(object):
             "-print_format", "json",
             "-show_format",
             "-show_streams",
+            "--",
             path
         ]
 


### PR DESCRIPTION
Makes possible this:
```
vcsi -- '-file.ts'
```
While before it just crashed right there.

It'd be better to add a test for this, but I'm not familiar with python ecosystem.

This was my use case, but I bet that's not the only place where ffprobe/ffmpeg get called with input parameters.