### PR TITLE
"is not" changed to "!="

### DIFF
--- a/vcsi/vcsi.py
+++ b/vcsi/vcsi.py
@@ -592,7 +592,7 @@ class MediaCapture(object):
         b = abs(numpy.fft.rfft2(a))
         max_freq = self.avg9x(b)
 
-        if max_freq is not 0:
+        if max_freq != 0:
             return 1 / max_freq
         else:
             return 1


### PR DESCRIPTION
There was an error in Python 3.8.2: "SyntaxWarning: "is not" with a literal. Did you mean "!="?"