### PR TITLE
Fix issue where ffmpeg may occasionally hang

### DIFF
--- a/vcsi/vcsi.py
+++ b/vcsi/vcsi.py
@@ -565,7 +565,7 @@ class MediaCapture(object):
                 ]
 
         try:
-            subprocess.call(ffmpeg_command, stderr=DEVNULL, stdout=DEVNULL)
+            subprocess.call(ffmpeg_command, stdin=DEVNULL, stderr=DEVNULL, stdout=DEVNULL)
         except FileNotFoundError:
             error = "Could not find 'ffmpeg' executable. Please make sure ffmpeg/ffprobe is installed and is in your PATH."
             error_exit(error)


### PR DESCRIPTION
Debugging revealed that ffmpeg was occasionally throwing
a strange error expecting input of some sort, which would cause
vcsi to hang.

https://unix.stackexchange.com/a/36411 reveals that this
is a semi-common issue when running a command in a loop,
and is resolved by setting stdin to /dev/null to ensure
that ffmpeg is not consuming anything to stdin from the loop.