### PR TITLE
update tests/ for pytest

### DIFF
--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,9 +1,7 @@
 from argparse import ArgumentTypeError
 from unittest.mock import patch, Mock, PropertyMock, MagicMock
 
-from nose.tools import assert_equals
-from nose.tools import assert_not_equals
-from nose.tools import assert_raises
+import pytest
 
 from vcsi.vcsi import Grid, mxn_type, Color, hex_color_type, manual_timestamps, timestamp_position_type, \
     TimestampPosition, comma_separated_string_type, metadata_position_type, cleanup, save_image,\
@@ -14,104 +12,104 @@ from vcsi import vcsi
 def test_grid_default():
     test_grid = mxn_type('4x4')
 
-    assert_equals(test_grid.x, 4)
-    assert_equals(test_grid.y, 4)
+    assert test_grid.x == 4
+    assert test_grid.y == 4
 
 
 def test_grid_equality():
     g1 = Grid(4, 4)
     g2 = Grid(4, 4)
-    assert_equals(g1, g2)
+    assert g1 == g2
 
 
 def test_grid_inequality():
     g1 = Grid(4, 4)
     g2 = Grid(3, 4)
-    assert_not_equals(g1, g2)
+    assert g1 != g2
 
 
 def test_grid_columns_integer():
-    assert_raises(ArgumentTypeError, mxn_type, 'ax4')
+    pytest.raises(ArgumentTypeError, mxn_type, 'ax4')
 
-    assert_raises(ArgumentTypeError, mxn_type, '4.1x4')
+    pytest.raises(ArgumentTypeError, mxn_type, '4.1x4')
 
 
 def test_grid_columns_positive():
-    assert_raises(ArgumentTypeError, mxn_type, '-1x4')
+    pytest.raises(ArgumentTypeError, mxn_type, '-1x4')
 
 
 def test_grid_rows_integer():
-    assert_raises(ArgumentTypeError, mxn_type, '4xa')
+    pytest.raises(ArgumentTypeError, mxn_type, '4xa')
 
-    assert_raises(ArgumentTypeError, mxn_type, '4x4.1')
+    pytest.raises(ArgumentTypeError, mxn_type, '4x4.1')
 
 
 def test_grid_rows_positive():
-    assert_raises(ArgumentTypeError, mxn_type, '4x-1')
+    pytest.raises(ArgumentTypeError, mxn_type, '4x-1')
 
 
 def test_grid_format():
-    assert_raises(ArgumentTypeError, mxn_type, '')
+    pytest.raises(ArgumentTypeError, mxn_type, '')
 
-    assert_raises(ArgumentTypeError, mxn_type, '4xx4')
+    pytest.raises(ArgumentTypeError, mxn_type, '4xx4')
 
-    assert_raises(ArgumentTypeError, mxn_type, '4x1x4')
+    pytest.raises(ArgumentTypeError, mxn_type, '4x1x4')
 
-    assert_raises(ArgumentTypeError, mxn_type, '4')
+    pytest.raises(ArgumentTypeError, mxn_type, '4')
 
 
 def test_hex_color_type():
-    assert_equals(Color(*(0x10, 0x10, 0x10, 0xff)), hex_color_type("101010"))
+    assert Color(*(0x10, 0x10, 0x10, 0xff)) == hex_color_type("101010")
 
-    assert_equals(Color(*(0x10, 0x10, 0x10, 0x00)), hex_color_type("10101000"))
+    assert Color(*(0x10, 0x10, 0x10, 0x00)) == hex_color_type("10101000")
 
-    assert_equals(Color(*(0xff, 0xff, 0xff, 0xff)), hex_color_type("ffffff"))
+    assert Color(*(0xff, 0xff, 0xff, 0xff)) == hex_color_type("ffffff")
 
-    assert_equals(Color(*(0xff, 0xff, 0xff, 0x00)), hex_color_type("ffffff00"))
+    assert Color(*(0xff, 0xff, 0xff, 0x00)) == hex_color_type("ffffff00")
 
-    assert_raises(ArgumentTypeError, hex_color_type, "abcdeff")
+    pytest.raises(ArgumentTypeError, hex_color_type, "abcdeff")
 
-    assert_raises(ArgumentTypeError, hex_color_type, "abcdfg")
+    pytest.raises(ArgumentTypeError, hex_color_type, "abcdfg")
 
 
 def test_manual_timestamps():
-    assert_equals(manual_timestamps("1:11:11.111,2:22:22.222"), ["1:11:11.111", "2:22:22.222"])
+    assert manual_timestamps("1:11:11.111,2:22:22.222") == ["1:11:11.111", "2:22:22.222"]
 
-    assert_raises(ArgumentTypeError, manual_timestamps, "1:11:a1.111,2:22:b2.222")
+    pytest.raises(ArgumentTypeError, manual_timestamps, "1:11:a1.111,2:22:b2.222")
 
-    assert_raises(ArgumentTypeError, manual_timestamps, "1:1:1:1.111,2:2.222")
+    pytest.raises(ArgumentTypeError, manual_timestamps, "1:1:1:1.111,2:2.222")
 
-    assert_equals(manual_timestamps(""), [])
+    assert manual_timestamps("") == []
 
 
 def test_timestamp_position_type():
-    assert_equals(timestamp_position_type("north"), TimestampPosition.north)
+    assert timestamp_position_type("north") == TimestampPosition.north
 
-    assert_not_equals(timestamp_position_type("south"), TimestampPosition.north)
+    assert timestamp_position_type("south") != TimestampPosition.north
 
-    assert_raises(ArgumentTypeError, timestamp_position_type, "whatever")
+    pytest.raises(ArgumentTypeError, timestamp_position_type, "whatever")
 
 
 @patch("vcsi.vcsi.parsedatetime")
 def test_interval_type(mocked_parsedatatime):
     mocked_parsedatatime.return_value = 30
-    assert_equals(mocked_parsedatatime("30 seconds"), 30)
+    assert mocked_parsedatatime("30 seconds") == 30
 
     mocked_parsedatatime.assert_called_once_with("30 seconds")
 
 
 def test_comma_separated_string_type():
-    assert_equals(comma_separated_string_type("a, b, c"), ["a", "b", "c"])
+    assert comma_separated_string_type("a, b, c") == ["a", "b", "c"]
 
-    assert_equals(comma_separated_string_type("a b, c"), ["a b", "c"])
+    assert comma_separated_string_type("a b, c") == ["a b", "c"]
 
 
 def test_metadata_position_type():
-    assert_equals(metadata_position_type("top"), "top")
+    assert metadata_position_type("top") == "top"
 
-    assert_equals(metadata_position_type("TOP"), "top")
+    assert metadata_position_type("TOP") == "top"
 
-    assert_raises(ArgumentTypeError, metadata_position_type, "whatever")
+    pytest.raises(ArgumentTypeError, metadata_position_type, "whatever")
 
 
 @patch("vcsi.vcsi.os")
@@ -130,7 +128,7 @@ def test_cleanup(mocked_os):
 def test_save_image(mocked_Image):
     args = PropertyMock()
     output_path = "whatever"
-    assert_equals(True, save_image(args, mocked_Image, None, output_path))
+    assert True == save_image(args, mocked_Image, None, output_path)
 
     mocked_Image.convert().save.assert_called_once()
 
@@ -145,17 +143,17 @@ def test_compute_timestamp_position():
     rectangle_hpadding, rectangle_vpadding = 5, 5
 
     args.timestamp_position = TimestampPosition.west
-    assert_equals(((1010, 500.0), (1030, 520.0)),
+    assert (((1010, 500.0), (1030, 520.0)) ==
                   compute_timestamp_position(args, w, h, text_size, desired_size, rectangle_hpadding,
                                              rectangle_vpadding))
 
     args.timestamp_position = TimestampPosition.north
-    assert_equals(((1000, 510.0), (1020, 530.0)),
+    assert (((1000, 510.0), (1020, 530.0)) ==
                   compute_timestamp_position(args, w, h, text_size, desired_size, rectangle_hpadding,
                                              rectangle_vpadding))
 
     args.timestamp_position = None
-    assert_equals(((990, 490), (1010, 510)),
+    assert (((990, 490), (1010, 510)) ==
                   compute_timestamp_position(args, w, h, text_size, desired_size, rectangle_hpadding,
                                              rectangle_vpadding))
 
@@ -168,19 +166,19 @@ def test_max_line_length():
     width = 1000
 
     text = "A long line of text"
-    assert_equals(19, max_line_length(media_info, metadata_font, header_margin, width, text))
+    assert 19 == max_line_length(media_info, metadata_font, header_margin, width, text)
 
     text = "A long line of text with a few more words"
-    assert_equals(41, max_line_length(media_info, metadata_font, header_margin, width, text))
+    assert 41 == max_line_length(media_info, metadata_font, header_margin, width, text)
 
     text = "A really long line of text with a lots more words" * 100
-    assert_equals(4900, max_line_length(media_info, metadata_font, header_margin, width, text))
+    assert 4900 == max_line_length(media_info, metadata_font, header_margin, width, text)
 
     text = None
     filename = PropertyMock()
     type(media_info).filename = filename
     # media_info.filename = filename
-    assert_equals(0, max_line_length(media_info, metadata_font, header_margin, width, text))
+    assert 0 == max_line_length(media_info, metadata_font, header_margin, width, text)
     filename.assert_called_once()
 
 
@@ -192,18 +190,18 @@ def test_draw_metadata():
     args.metadata_vertical_margin = 0
     header_lines.__iter__ = Mock(return_value=iter(['text1', 'text2']))
 
-    assert_equals(0, draw_metadata(draw, args,
+    assert 0 == draw_metadata(draw, args,
                                    header_lines=header_lines,
                                    header_line_height=0,
-                                   start_height=0))
+                                   start_height=0)
     draw.text.assert_called()
 
 
 def test_grid():
-    assert_equals("2x2", Grid(2, 2).__str__())
+    assert "2x2" == Grid(2, 2).__str__()
 
-    assert_equals("10x0", Grid(10, 0).__str__())
+    assert "10x0" == Grid(10, 0).__str__()
 
 def test_color():
-    assert_equals("FFFFFFFF", Color(255, 255, 255, 255).__str__())
+    assert "FFFFFFFF" == Color(255, 255, 255, 255).__str__()
 

--- a/tests/test_mediainfo.py
+++ b/tests/test_mediainfo.py
@@ -2,8 +2,7 @@ import json
 import argparse
 from argparse import ArgumentTypeError
 
-from nose.tools import assert_raises
-from nose.tools import assert_equals
+import pytest
 
 from vcsi.vcsi import MediaInfo
 from vcsi.vcsi import Grid, grid_desired_size
@@ -25,40 +24,40 @@ class MediaInfoForTest(MediaInfo):
 
 def test_compute_display_resolution():
     mi = MediaInfoForTest(FFPROBE_EXAMPLE_JSON_PATH)
-    assert_equals(mi.display_width, 1920)
-    assert_equals(mi.display_height, 1080)
+    assert mi.display_width == 1920
+    assert mi.display_height == 1080
 
 
 def test_filename():
     mi = MediaInfoForTest(FFPROBE_EXAMPLE_JSON_PATH)
-    assert_equals(mi.filename, "bbb_sunflower_1080p_60fps_normal.mp4")
+    assert mi.filename == "bbb_sunflower_1080p_60fps_normal.mp4"
 
 
 def test_duration():
     mi = MediaInfoForTest(FFPROBE_EXAMPLE_JSON_PATH)
-    assert_equals(mi.duration_seconds, 634.533333)
+    assert mi.duration_seconds == 634.533333
 
 
 def test_pretty_duration():
     mi = MediaInfoForTest(FFPROBE_EXAMPLE_JSON_PATH)
-    assert_equals(mi.duration, "10:34")
+    assert mi.duration == "10:34"
 
 
 def test_size_bytes():
     mi = MediaInfoForTest(FFPROBE_EXAMPLE_JSON_PATH)
-    assert_equals(mi.size_bytes, 355856562)
+    assert mi.size_bytes == 355856562
 
 
 def test_size():
     mi = MediaInfoForTest(FFPROBE_EXAMPLE_JSON_PATH)
-    assert_equals(mi.size, "339.4 MiB")
+    assert mi.size == "339.4 MiB"
 
 
 def test_template_attributes():
     mi = MediaInfoForTest(FFPROBE_EXAMPLE_JSON_PATH)
     attributes = mi.template_attributes()
-    assert_equals(attributes["audio_codec"], "mp3")
-    assert_equals(attributes["video_codec"], "h264")
+    assert attributes["audio_codec"] == "mp3"
+    assert attributes["video_codec"] == "h264"
 
 
 def test_grid_desired_size():
@@ -71,13 +70,13 @@ def test_grid_desired_size():
     s = grid_desired_size(grid, mi, width=width, horizontal_margin=hmargin)
     expected_width = (width - (x-1) * hmargin) / x
 
-    assert_equals(s[0], expected_width)
+    assert s[0] == expected_width
 
 
 def test_desired_size():
     mi = MediaInfoForTest(FFPROBE_EXAMPLE_JSON_PATH)
     s = mi.desired_size(width=1280)
-    assert_equals(s[1], 720)
+    assert s[1] == 720
 
 
 def test_timestamps():
@@ -96,7 +95,7 @@ def test_timestamps():
 
     expected_timestamp = start_delay_percent + 1
     for t in timestamp_generator(mi, args):
-        assert_equals(int(t[0]), expected_timestamp)
+        assert int(t[0]) == expected_timestamp
         expected_timestamp += 1
 
 
@@ -104,21 +103,21 @@ def test_pretty_duration_centis_limit():
     mi = MediaInfoForTest(FFPROBE_EXAMPLE_JSON_PATH)
     mi.duration_seconds = 1.9999
     pretty_duration = MediaInfo.pretty_duration(mi.duration_seconds, show_centis=True)
-    assert_equals(pretty_duration, "00:01.99")
+    assert pretty_duration == "00:01.99"
 
 
 def test_pretty_duration_millis_limit():
     mi = MediaInfoForTest(FFPROBE_EXAMPLE_JSON_PATH)
     mi.duration_seconds = 1.9999
     pretty_duration = MediaInfo.pretty_duration(mi.duration_seconds, show_millis=True)
-    assert_equals(pretty_duration, "00:01.999")
+    assert pretty_duration == "00:01.999"
 
 
 def test_pretty_to_seconds():
-    assert_equals(MediaInfo.pretty_to_seconds("1:11:11.111"), 4271.111)
+    assert MediaInfo.pretty_to_seconds("1:11:11.111") == 4271.111
 
-    assert_equals(MediaInfo.pretty_to_seconds("1:11:11"), 4271)
+    assert MediaInfo.pretty_to_seconds("1:11:11") == 4271
 
-    assert_equals(MediaInfo.pretty_to_seconds("1:01:00"), 3660)
+    assert MediaInfo.pretty_to_seconds("1:01:00") == 3660
 
-    assert_raises(ArgumentTypeError, MediaInfo.pretty_to_seconds, "1:01:01:01:00")
+    pytest.raises(ArgumentTypeError, MediaInfo.pretty_to_seconds, "1:01:01:01:00")


### PR DESCRIPTION
Note: I have no idea what I'm doing. 

I used https://pypi.org/project/nose2pytest/, 
manually removed `from nose.tools import...`, 
manually added `import pytest` and with these tests pass for me. 

```
python3.8 -m pytest -vv -ra -l -Wdefault --color=no -o console_output_style=count -p no:cov -p no:flake8 -p no:flakes -p no:pylint -p no:markdown -p no:sugar -p no:xvfb
======================================== test session starts ========================================
platform linux -- Python 3.8.15, pytest-7.2.0, pluggy-1.0.0 -- /usr/bin/python3.8
cachedir: .pytest_cache
rootdir: /var/tmp/portage/media-video/vcsi-7.0.13-r1/work/vcsi-264f89402c2a6d71e2db6693e802b82f5b8d3fd9
plugins: pkgcore-0.12.16, nose2pytest-1.0.8
collecting ... collected 34 items

tests/test_input.py::test_grid_default PASSED                                                [ 1/34]
tests/test_input.py::test_grid_equality PASSED                                               [ 2/34]
tests/test_input.py::test_grid_inequality PASSED                                             [ 3/34]
tests/test_input.py::test_grid_columns_integer PASSED                                        [ 4/34]
tests/test_input.py::test_grid_columns_positive PASSED                                       [ 5/34]
tests/test_input.py::test_grid_rows_integer PASSED                                           [ 6/34]
tests/test_input.py::test_grid_rows_positive PASSED                                          [ 7/34]
tests/test_input.py::test_grid_format PASSED                                                 [ 8/34]
tests/test_input.py::test_hex_color_type PASSED                                              [ 9/34]
tests/test_input.py::test_manual_timestamps PASSED                                           [10/34]
tests/test_input.py::test_timestamp_position_type PASSED                                     [11/34]
tests/test_input.py::test_interval_type PASSED                                               [12/34]
tests/test_input.py::test_comma_separated_string_type PASSED                                 [13/34]
tests/test_input.py::test_metadata_position_type PASSED                                      [14/34]
tests/test_input.py::test_cleanup PASSED                                                     [15/34]
tests/test_input.py::test_save_image PASSED                                                  [16/34]
tests/test_input.py::test_compute_timestamp_position PASSED                                  [17/34]
tests/test_input.py::test_max_line_length PASSED                                             [18/34]
tests/test_input.py::test_draw_metadata PASSED                                               [19/34]
tests/test_input.py::test_grid PASSED                                                        [20/34]
tests/test_input.py::test_color PASSED                                                       [21/34]
tests/test_mediainfo.py::test_compute_display_resolution PASSED                              [22/34]
tests/test_mediainfo.py::test_filename PASSED                                                [23/34]
tests/test_mediainfo.py::test_duration PASSED                                                [24/34]
tests/test_mediainfo.py::test_pretty_duration PASSED                                         [25/34]
tests/test_mediainfo.py::test_size_bytes PASSED                                              [26/34]
tests/test_mediainfo.py::test_size PASSED                                                    [27/34]
tests/test_mediainfo.py::test_template_attributes PASSED                                     [28/34]
tests/test_mediainfo.py::test_grid_desired_size PASSED                                       [29/34]
tests/test_mediainfo.py::test_desired_size PASSED                                            [30/34]
tests/test_mediainfo.py::test_timestamps PASSED                                              [31/34]
tests/test_mediainfo.py::test_pretty_duration_centis_limit PASSED                            [32/34]
tests/test_mediainfo.py::test_pretty_duration_millis_limit PASSED                            [33/34]
tests/test_mediainfo.py::test_pretty_to_seconds PASSED                                       [34/34]

======================================== 34 passed in 0.22s =========================================
```
```
python3.9 -m pytest -vv -ra -l -Wdefault --color=no -o console_output_style=count -p no:cov -p no:flake8 -p no:flakes -p no:pylint -p no:markdown -p no:sugar -p no:xvfb
======================================== test session starts ========================================
platform linux -- Python 3.9.15, pytest-7.2.0, pluggy-1.0.0 -- /usr/bin/python3.9
cachedir: .pytest_cache
rootdir: /var/tmp/portage/media-video/vcsi-7.0.13-r1/work/vcsi-264f89402c2a6d71e2db6693e802b82f5b8d3fd9
plugins: pkgcore-0.12.16
collecting ... collected 34 items

tests/test_input.py::test_grid_default PASSED                                                [ 1/34]
tests/test_input.py::test_grid_equality PASSED                                               [ 2/34]
tests/test_input.py::test_grid_inequality PASSED                                             [ 3/34]
tests/test_input.py::test_grid_columns_integer PASSED                                        [ 4/34]
tests/test_input.py::test_grid_columns_positive PASSED                                       [ 5/34]
tests/test_input.py::test_grid_rows_integer PASSED                                           [ 6/34]
tests/test_input.py::test_grid_rows_positive PASSED                                          [ 7/34]
tests/test_input.py::test_grid_format PASSED                                                 [ 8/34]
tests/test_input.py::test_hex_color_type PASSED                                              [ 9/34]
tests/test_input.py::test_manual_timestamps PASSED                                           [10/34]
tests/test_input.py::test_timestamp_position_type PASSED                                     [11/34]
tests/test_input.py::test_interval_type PASSED                                               [12/34]
tests/test_input.py::test_comma_separated_string_type PASSED                                 [13/34]
tests/test_input.py::test_metadata_position_type PASSED                                      [14/34]
tests/test_input.py::test_cleanup PASSED                                                     [15/34]
tests/test_input.py::test_save_image PASSED                                                  [16/34]
tests/test_input.py::test_compute_timestamp_position PASSED                                  [17/34]
tests/test_input.py::test_max_line_length PASSED                                             [18/34]
tests/test_input.py::test_draw_metadata PASSED                                               [19/34]
tests/test_input.py::test_grid PASSED                                                        [20/34]
tests/test_input.py::test_color PASSED                                                       [21/34]
tests/test_mediainfo.py::test_compute_display_resolution PASSED                              [22/34]
tests/test_mediainfo.py::test_filename PASSED                                                [23/34]
tests/test_mediainfo.py::test_duration PASSED                                                [24/34]
tests/test_mediainfo.py::test_pretty_duration PASSED                                         [25/34]
tests/test_mediainfo.py::test_size_bytes PASSED                                              [26/34]
tests/test_mediainfo.py::test_size PASSED                                                    [27/34]
tests/test_mediainfo.py::test_template_attributes PASSED                                     [28/34]
tests/test_mediainfo.py::test_grid_desired_size PASSED                                       [29/34]
tests/test_mediainfo.py::test_desired_size PASSED                                            [30/34]
tests/test_mediainfo.py::test_timestamps PASSED                                              [31/34]
tests/test_mediainfo.py::test_pretty_duration_centis_limit PASSED                            [32/34]
tests/test_mediainfo.py::test_pretty_duration_millis_limit PASSED                            [33/34]
tests/test_mediainfo.py::test_pretty_to_seconds PASSED                                       [34/34]

======================================== 34 passed in 0.24s =========================================
```
```
python3.10 -m pytest -vv -ra -l -Wdefault --color=no -o console_output_style=count -p no:cov -p no:flake8 -p no:flakes -p no:pylint -p no:markdown -p no:sugar -p no:xvfb
======================================== test session starts ========================================
platform linux -- Python 3.10.8, pytest-7.2.0, pluggy-1.0.0 -- /usr/bin/python3.10
cachedir: .pytest_cache
rootdir: /var/tmp/portage/media-video/vcsi-7.0.13-r1/work/vcsi-264f89402c2a6d71e2db6693e802b82f5b8d3fd9
plugins: pkgcore-0.12.16
collecting ... collected 34 items

tests/test_input.py::test_grid_default PASSED                                                [ 1/34]
tests/test_input.py::test_grid_equality PASSED                                               [ 2/34]
tests/test_input.py::test_grid_inequality PASSED                                             [ 3/34]
tests/test_input.py::test_grid_columns_integer PASSED                                        [ 4/34]
tests/test_input.py::test_grid_columns_positive PASSED                                       [ 5/34]
tests/test_input.py::test_grid_rows_integer PASSED                                           [ 6/34]
tests/test_input.py::test_grid_rows_positive PASSED                                          [ 7/34]
tests/test_input.py::test_grid_format PASSED                                                 [ 8/34]
tests/test_input.py::test_hex_color_type PASSED                                              [ 9/34]
tests/test_input.py::test_manual_timestamps PASSED                                           [10/34]
tests/test_input.py::test_timestamp_position_type PASSED                                     [11/34]
tests/test_input.py::test_interval_type PASSED                                               [12/34]
tests/test_input.py::test_comma_separated_string_type PASSED                                 [13/34]
tests/test_input.py::test_metadata_position_type PASSED                                      [14/34]
tests/test_input.py::test_cleanup PASSED                                                     [15/34]
tests/test_input.py::test_save_image PASSED                                                  [16/34]
tests/test_input.py::test_compute_timestamp_position PASSED                                  [17/34]
tests/test_input.py::test_max_line_length PASSED                                             [18/34]
tests/test_input.py::test_draw_metadata PASSED                                               [19/34]
tests/test_input.py::test_grid PASSED                                                        [20/34]
tests/test_input.py::test_color PASSED                                                       [21/34]
tests/test_mediainfo.py::test_compute_display_resolution PASSED                              [22/34]
tests/test_mediainfo.py::test_filename PASSED                                                [23/34]
tests/test_mediainfo.py::test_duration PASSED                                                [24/34]
tests/test_mediainfo.py::test_pretty_duration PASSED                                         [25/34]
tests/test_mediainfo.py::test_size_bytes PASSED                                              [26/34]
tests/test_mediainfo.py::test_size PASSED                                                    [27/34]
tests/test_mediainfo.py::test_template_attributes PASSED                                     [28/34]
tests/test_mediainfo.py::test_grid_desired_size PASSED                                       [29/34]
tests/test_mediainfo.py::test_desired_size PASSED                                            [30/34]
tests/test_mediainfo.py::test_timestamps PASSED                                              [31/34]
tests/test_mediainfo.py::test_pretty_duration_centis_limit PASSED                            [32/34]
tests/test_mediainfo.py::test_pretty_duration_millis_limit PASSED                            [33/34]
tests/test_mediainfo.py::test_pretty_to_seconds PASSED                                       [34/34]

======================================== 34 passed in 0.23s =========================================
```
```
