### PR TITLE
Improve handling of non-zero ffmpeg responses

### DIFF
--- a/vcsi/vcsi.py
+++ b/vcsi/vcsi.py
@@ -572,10 +572,17 @@ class MediaCapture(object):
                 ]
 
         try:
-            subprocess.call(ffmpeg_command, stdin=DEVNULL, stderr=DEVNULL, stdout=DEVNULL)
+            subprocess.run(ffmpeg_command, stdin=DEVNULL, capture_output=True, check=True)
         except FileNotFoundError:
             error = "Could not find 'ffmpeg' executable. Please make sure ffmpeg/ffprobe is installed and is in your PATH."
             error_exit(error)
+        except subprocess.CalledProcessError as ex:
+            raise RuntimeError("\n".join([
+                "ffmpeg had an error while decoding the file:",
+                f"Command: '{" ".join(ex.cmd)}'",
+                f"Exit code: {ex.returncode}",
+                f"Output: {ex.stderr.decode("utf-8")}",
+            ])) from None
 
     def compute_avg_color(self, image_path):
         """Computes the average color of an image


### PR DESCRIPTION
Currently 'make_capture()' just drops the output from the ffmpeg CLI.

By switching to 'subprocess.run()' it is possible to handle non-zero exit codes from the ffmpeg CLI. This prints out the full ffmpeg command, exit code and the response from ffmpeg which should be enough for a tech-savvy user to debug.

Given this will nearly always be an issue with the ffmpeg installation or the file there isn't anything more vcsi can do in this situation.

This is implemented as an exception so that when run with '--ignore-errors' the file can be skipped.

Fixes: https://github.com/amietn/vcsi/issues/104
Fixes: https://github.com/amietn/vcsi/issues/103
Fixes: https://github.com/amietn/vcsi/issues/86
Fixes: https://github.com/amietn/vcsi/issues/82
Fixes: https://github.com/amietn/vcsi/issues/75