### PR TITLE
Add file_path metadata to template attributes

### DIFF
--- a/vcsi/vcsi.py
+++ b/vcsi/vcsi.py
@@ -472,7 +472,7 @@ class MediaInfo(object):
         table.append({"name": "size", "description": "File size (pretty format)", "example": "128.3 MiB"})
         table.append({"name": "size_bytes", "description": "File size (bytes)", "example": "4662788373"})
         table.append({"name": "filename", "description": "File name", "example": "video.mkv"})
-        table.append({"name": "file_path", "description": "Full file path", "example": "/home/user/videos/video.mkv"})
+        table.append({"name": "file_path", "description": "Full file path", "example": "/home/user/vids/video.mkv"})
         table.append({"name": "duration", "description": "Duration (pretty format)", "example": "03:07"})
         table.append({"name": "sample_width", "description": "Sample width (pixels)", "example": "1920"})
         table.append({"name": "sample_height", "description": "Sample height (pixels)", "example": "1080"})


### PR DESCRIPTION
Lets users use the full file path of the video file in their template

![Shrek_1 mp4](https://github.com/user-attachments/assets/a68e2b65-00cb-4862-a42f-4f990a6fc49f)

![image](https://github.com/user-attachments/assets/451e5695-b14d-447f-a3b6-61ee7171f4c3)
